### PR TITLE
Add Markdown Link Checker

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,4 @@
+dirs:
+  - ./
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -67,3 +67,21 @@ jobs:
 
       - name: Check Python Code Format (Ruff)
         run: just ruff-format
+
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter


### PR DESCRIPTION
# Description

This change introduces a new workflow step to check Markdown links in the repository. A new configuration file `.linkspector.yml` is added to specify the directories to scan and the acceptable status codes for live links. The `code-quality.yml` workflow is updated to include a new job called `check-markdown-links`, which uses the UmbrellaDocs/action-linkspector action to perform the link checking. 

fixes #27