### PR TITLE
Add Justfile Format Check to Workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -85,3 +85,18 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
+      - name: Check Justfile Format
+        run: just format-check


### PR DESCRIPTION
# Description

This change adds a new job to the code quality workflow to check the formatting of the Justfile. The new job, named "check-justfile-format", runs on Ubuntu and performs the following steps:

1. Checks out the repository
2. Sets up the Just command runner
3. Executes the "just format-check" command to verify the Justfile's formatting

This addition helps ensure consistent formatting of the Justfile across the project.

fixes #21