### PR TITLE
Add Git Hooks and Pre-commit Scripts

### DIFF
--- a/githooks/post-commit
+++ b/githooks/post-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e +x
+
+git update-index -g

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e +x
+
+# shellcheck disable=SC2045,SC2028,SC2086,SC2206,SC2128
+for script in $(ls -1 githooks/pre-commit-scripts/*.sh 2>/dev/null); do
+  ts=$SECONDS
+  echo "Running githook: $script"
+  bash $script
+  te=($SECONDS - $ts)
+  echo "Script Took (${te}s)"
+done
+
+printf "pre-commit completed successfully"

--- a/githooks/pre-commit-scripts/gitleaks.sh
+++ b/githooks/pre-commit-scripts/gitleaks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+gitleaks detect --source .

--- a/githooks/pre-commit-scripts/justfile.sh
+++ b/githooks/pre-commit-scripts/justfile.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+just format

--- a/githooks/pre-commit-scripts/prettier.sh
+++ b/githooks/pre-commit-scripts/prettier.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+just prettier-format

--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e +x
+
+just install
+just ruff-fix


### PR DESCRIPTION
# Description

This change introduces a set of Git hooks to enhance the development workflow:

1. A post-commit hook that updates the Git index.
2. A pre-commit hook that executes a series of scripts before each commit.
3. Four pre-commit scripts:
   - Gitleaks: Detects potential secrets in the codebase.
   - Justfile: Runs the 'format' command from the project's Justfile.
   - Prettier: Executes the 'prettier-format' command from the Justfile.
   - Python: Installs dependencies and runs 'ruff-fix' for Python code formatting.

These hooks aim to automate code quality checks, formatting, and security scans, ensuring consistent and secure commits across the project.

fixes #15