### PR TITLE
Fix SonarCloud Coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -20,7 +20,7 @@ install:
     poetry install
 
 test:
-    poetry run pytest challenges --cov=challenges --cov-report=xml
+    poetry run pytest challenges --cov=. --cov-report=xml
 
 # ------------------------------------------------------------------------------
 # Ruff - # Set up red-knot when it's ready


### PR DESCRIPTION
# Description

Added an empty `__init__.py` file to the root directory, which marks the directory as a Python package. This allows the directory to be imported as a module in other Python scripts.

fixes #52