### PR TITLE
Optimise Python Pre-commit Hook for Challenges Folder

### DIFF
--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e +x
 
-just install
-just ruff-fix
+# Check if there are any changes in the watched folder
+if git diff --cached --name-only | grep -q "^challenges/"; then
+  just install
+  just ruff-fix
+fi


### PR DESCRIPTION
# Description

This change modifies the `python.sh` pre-commit script to only run the `just install` and `just ruff-fix` commands when there are changes in the `challenges/` directory. It adds a conditional check using `git diff --cached --name-only` to determine if any files in the watched folder have been modified before executing the commands.

fixes #56