### PR TITLE
Add Size Labels to GitHub Configuration

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -49,3 +49,22 @@
 - color: ff0073
   name: git_hooks
   description: Pull requests that update git hooks
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request


### PR DESCRIPTION
# Description

Added new labels to categorise pull requests based on their size. The new labels include:

- size/XS: Extra Small Pull Request
- size/S: Small Pull Request
- size/M: Medium Pull Request
- size/L: Large Pull Request
- size/XL: Extra Large Pull Request
- size/XXL: Extra Extra Large Pull Request

Each size label is assigned a unique colour for easy visual identification.

fixes #62