### PR TITLE
Enhance Pull Request Size Labelling

### DIFF
--- a/.github/workflows/pull-request-labeller.yml
+++ b/.github/workflows/pull-request-labeller.yml
@@ -21,7 +21,8 @@ jobs:
     name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5.0.0
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
@@ -31,3 +32,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
# Description

This change enhances the pull request labelling workflow by adding a name to the labeller action step and configuring size labels for pull requests. The size labels are now defined with specific thresholds, categorising pull requests as XS, S, M, L, XL, or XXL based on the number of lines changed. This addition will provide more granular information about the scope of each pull request.

fixes #68