### PR TITLE
Adjust Pull Request Size Labelling Thresholds

### DIFF
--- a/.github/workflows/pull-request-labeller.yml
+++ b/.github/workflows/pull-request-labeller.yml
@@ -32,13 +32,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          with:
+        with:
           sizes: >
             {
               "0": "XS",
-              "20": "S",
-              "50": "M",
+              "40": "S",
+              "100": "M",
               "200": "L",
-              "500": "XL",
-              "1000": "XXL"
+              "800": "XL",
+              "2000": "XXL"
             }


### PR DESCRIPTION
# Pull Request

## Description

This change updates the size thresholds for pull request labels in the GitHub Actions workflow. The new thresholds are:

- XS: 0-39 lines
- S: 40-99 lines
- M: 100-199 lines
- L: 200-799 lines
- XL: 800-1999 lines
- XXL: 2000+ lines

These adjustments provide a more granular categorisation of pull request sizes, allowing for better organisation and review prioritisation.

fixes #72