### PR TITLE
Streamline Pre-commit Hooks and Enhance Justfile Commands

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -19,7 +19,7 @@ just:
 shell:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["**/*.sh"]
+          - any-glob-to-any-file: ["**/*.sh", "pre-commit", "post-commit"]
 github_actions:
   - any:
       - changed-files:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -87,4 +87,4 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Check Justfile Format
-        run: just format-check
+        run: just just-format-check

--- a/Justfile
+++ b/Justfile
@@ -71,13 +71,21 @@ prettier-format:
 # Justfile
 # ------------------------------------------------------------------------------
 
-# Format Justfile
-format:
+# Format the justfile
+just-format:
     just --fmt --unstable
 
-# Check Justfile format
-format-check:
+# Check if the justfile is formatted correctly
+just-format-check:
     just --fmt --check --unstable
+
+# ------------------------------------------------------------------------------
+# Git Leaks
+# ------------------------------------------------------------------------------
+
+# Detect secrets in the repos
+gitleaks-detect:
+    gitleaks detect --source .
 
 # ------------------------------------------------------------------------------
 # Git Hooks

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,13 +1,12 @@
 #!/bin/bash
-set -e +x
+set -e
 
+printf "Running Mandatory Checks \n"
+
+just --quiet gitleaks-detect just-format prettier-check
+
+printf "Running Optional Checks \n"
 # shellcheck disable=SC2045,SC2028,SC2086,SC2206,SC2128
 for script in $(ls -1 githooks/pre-commit-scripts/*.sh 2>/dev/null); do
-  ts=$SECONDS
-  echo "Running githook: $script"
   bash $script
-  te=($SECONDS - $ts)
-  echo "Script Took (${te}s)"
 done
-
-printf "pre-commit completed successfully"

--- a/githooks/pre-commit-scripts/gitleaks.sh
+++ b/githooks/pre-commit-scripts/gitleaks.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-gitleaks detect --source .

--- a/githooks/pre-commit-scripts/justfile.sh
+++ b/githooks/pre-commit-scripts/justfile.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-just format

--- a/githooks/pre-commit-scripts/prettier.sh
+++ b/githooks/pre-commit-scripts/prettier.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e +x
-
-just prettier-format

--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -3,6 +3,5 @@ set -e +x
 
 # Check if there are any changes in the watched folder
 if git diff --cached --name-only | grep -q "^challenges/"; then
-  just install
-  just ruff-fix
+  just --quiet install ruff-fix
 fi


### PR DESCRIPTION
# Pull Request

## Description

This change restructures the pre-commit hook system to improve organisation and execution of checks. The main updates include:

1. Separating checks into mandatory and optional categories.
2. Integrating gitleaks, justfile formatting, and prettier checks into the main pre-commit script as mandatory checks.
3. Removing individual script files for gitleaks, justfile, and prettier.
4. Adding a new `just-format-check` command to verify justfile formatting.
5. Introducing a `gitleaks-detect` command in the Justfile for secret detection.
6. Simplifying the main pre-commit script by removing execution time reporting and unnecessary echo statements.
7. Updating the Justfile with new commands for formatting and checking justfile itself.
8. Modifying the labeller configuration to include 'pre-commit' and 'post-commit' files under the 'shell' label.
9. Updating the code-quality workflow to use the new `just-format-check` command.

These changes aim to streamline the pre-commit process and provide a clearer distinction between essential and supplementary checks, while improving the overall efficiency of the hook system.

fixes #79