### PR TITLE
Update GitHub Actions Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change specifies the types of updates allowed for GitHub Actions dependencies, adding "patch" and "minor" update types.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R18-R20): Added "patch" and "minor" update types for GitHub Actions dependencies.

Fixes #103 