### PR TITLE
chore: Ungroup Major Application Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,6 @@ updates:
       python:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/dependabot.yml` file. The change specifies the types of updates for Python dependencies, including patch and minor updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R34-R36): Added `update-types` for Python dependencies to include "patch" and "minor".

Fixes #106