### PR TITLE
Remove Custom Python Line Length

### DIFF
--- a/challenges/leetcode/66_plus_one/test_challenge.py
+++ b/challenges/leetcode/66_plus_one/test_challenge.py
@@ -15,7 +15,9 @@ from challenge import Solution
         ([9, 9, 9, 9, 9], [1, 0, 0, 0, 0, 0]),
     ],
 )
-def test_solution__plus_one(function_input: list[int], expected_output: list[int]) -> None:
+def test_solution__plus_one(
+    function_input: list[int], expected_output: list[int]
+) -> None:
     # Act
     output = Solution().plusOne(function_input)
     # Assert

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,9 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-line-length = 120
 target-version = "py313"
 
 [tool.ruff.lint]
-extend-select = ["E501"]
 select = ["ALL"]
 
 ignore = [


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a couple of changes to improve code formatting and update configurations.

Code formatting improvements:

* [`challenges/leetcode/66_plus_one/test_challenge.py`](diffhunk://#diff-dadc9971b1c9a2e94eb8c21472f3b3cc27dbaa7c1da527c39c81a400238b5d70L18-R20): Reformatted the `test_solution__plus_one` function to improve readability by splitting the parameters onto separate lines.

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22-L26): Removed the `line-length` setting from the `[tool.ruff]` section.
