### PR TITLE
Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -97,7 +97,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/workflows/code-checks.yml` file. The changes include updating the Ubuntu version and the action version used for checking Markdown links.

* Updated the `runs-on` parameter to use `ubuntu-latest` instead of `ubuntu-22.04`.
* Updated the `UmbrellaDocs/action-linkspector` action version from `v1.2.4` to `v1.2.5`.