### PR TITLE
Bump GitHub Action Versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -61,7 +61,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.8
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -145,12 +145,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.1
+        uses: github/codeql-action/init@v3.28.8
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.1
+        uses: github/codeql-action/analyze@v3.28.8
 
   run-zizmor:
     name: Check GitHub Actions with zizmor
@@ -170,7 +170,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.8
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/code-checks.yml` file to ensure the use of the latest version of the `codeql-action` for various steps.

Version updates:

* Updated the `upload-sarif` action to version `v3.28.8` for uploading analysis results to GitHub.
* Updated the `init` action to version `v3.28.8` for initializing CodeQL.
* Updated the `analyze` action to version `v3.28.8` for performing CodeQL analysis.
* Updated the `upload-sarif` action to version `v3.28.8` for uploading the SARIF file.